### PR TITLE
Use prefix status codes for older FTP implementations

### DIFF
--- a/tinyftp.go
+++ b/tinyftp.go
@@ -136,9 +136,9 @@ func (c *Conn) Passive() (addr string, code int, message string, err error) {
 // List the specified directory.
 func (c *Conn) List(dir string, dconn net.Conn) (dirList []string, code int, message string, err error) {
 	if len(dir) != 0 {
-		code, message, err = c.Cmd(125, "LIST %s", dir)
+		code, message, err = c.Cmd(1, "LIST %s", dir)
 	} else {
-		code, message, err = c.Cmd(125, "LIST")
+		code, message, err = c.Cmd(1, "LIST")
 	}
 	if err != nil {
 		return nil, code, message, err
@@ -158,9 +158,9 @@ func (c *Conn) List(dir string, dconn net.Conn) (dirList []string, code int, mes
 // List the specified directory, names only.
 func (c *Conn) NameList(dir string, dconn net.Conn) (dirList []string, code int, message string, err error) {
 	if len(dir) != 0 {
-		code, message, err = c.Cmd(125, "NLST %s", dir)
+		code, message, err = c.Cmd(1, "NLST %s", dir)
 	} else {
-		code, message, err = c.Cmd(125, "NLST")
+		code, message, err = c.Cmd(1, "NLST")
 	}
 	if err != nil {
 		return nil, code, message, err
@@ -198,7 +198,7 @@ func (c *Conn) Rest(size int64) (code int, message string, err error) {
 
 // Retrieve the named file
 func (c *Conn) Retrieve(fname string, dconn net.Conn) (contents []byte, code int, message string, err error) {
-	code, message, err = c.Cmd(125, "RETR %s", fname)
+	code, message, err = c.Cmd(1, "RETR %s", fname)
 	if err != nil {
 		return nil, code, message, err
 	}
@@ -212,7 +212,7 @@ func (c *Conn) Retrieve(fname string, dconn net.Conn) (contents []byte, code int
 
 // Retrieve the named file to the given io.Writer.
 func (c *Conn) RetrieveTo(fname string, dconn net.Conn, w io.Writer) (written int64, code int, message string, err error) {
-	code, message, err = c.Cmd(125, "RETR %s", fname)
+	code, message, err = c.Cmd(1, "RETR %s", fname)
 	if err != nil {
 		return 0, code, message, err
 	}


### PR DESCRIPTION
Some older FTP implementations send 125 status codes instead of 150. Under the spec, both are valid, as should all 1xx status codes. (thought they could possible indicate additional work?)

This changes the resulting expectations.

This means that in addition to a 125, the following are also valid:

110 - Restart marker replay . In this case, the text is exact and not left to the particular implementation; it must read: MARK yyyy = mmmm where yyyy is User-process data stream marker, and mmmm server's equivalent marker (note the spaces between markers and "=").
120 - Service ready in nnn minutes.

I am not familiar enough with FTP to know what the implication of expecting these codes are, but this solution is good enough for us...

If you have any feedback on how to make it more reliable, let me know!
