### PR TITLE
Added DialTimeout

### DIFF
--- a/tinyftp.go
+++ b/tinyftp.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Conn struct {
@@ -38,6 +39,17 @@ func NewConn(nconn io.ReadWriteCloser) (conn *Conn, code int, message string, er
 // and then returns a new Conn for the connection.
 func Dial(network, addr string) (conn *Conn, code int, message string, err error) {
 	nconn, err := net.Dial(network, addr)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	conn, code, message, err = NewConn(nconn)
+	return
+}
+
+// DialTimeout connects to the given address on the given network with a timeout and
+// then returns a new Conn for the connection.
+func DialTimeout(network, addr string, timeout time.Duration) (conn *Conn, code int, message string, err error) {
+	nconn, err := net.DialTimeout(network, addr, timeout)
 	if err != nil {
 		return nil, 0, "", err
 	}

--- a/tinyftp_test.go
+++ b/tinyftp_test.go
@@ -2,8 +2,8 @@ package tinyftp
 
 import (
 	"net"
-	"time"
 	"testing"
+	"time"
 )
 
 const (
@@ -76,5 +76,12 @@ func TestTinyFTP1(t *testing.T) {
 }
 
 func TestTinyFTP2(t *testing.T) {
-	testNameList(t, ftpHost2, ftpDir2 + time.Now().Format("20060102"))
+	testNameList(t, ftpHost2, ftpDir2+time.Now().Format("20060102"))
+}
+
+func TestTinyFTP3(t *testing.T) {
+	_, _, _, err := DialTimeout("tcp", "localhost:21", time.Nanosecond)
+	if neterr, ok := err.(net.Error); ok && !neterr.Timeout() {
+		t.Fatal("Expected a timeout to occur")
+	}
 }


### PR DESCRIPTION
Hi!

These changes add a DialTimeout function, which simply calls into net.DialTimeout instead of net.Dial when connecting.
