### PR TITLE
Close Data connection prior to reading 2XX response?

### DIFF
--- a/tinyftp.go
+++ b/tinyftp.go
@@ -165,7 +165,10 @@ func (c *Conn) List(dir string, dconn net.Conn) (dirList []string, code int, mes
 	if err != nil {
 		return nil, code, message, err
 	}
-	dconn.Close()
+	err = dconn.Close()
+	if err != nil {
+		return nil, code, message, err
+	}
 
 	code, message, err = c.conn.ReadResponse(2)
 	return
@@ -191,7 +194,10 @@ func (c *Conn) NameList(dir string, dconn net.Conn) (dirList []string, code int,
 	if err != nil {
 		return nil, code, message, err
 	}
-	dconn.Close()
+	err = dconn.Close()
+	if err != nil {
+		return nil, code, message, err
+	}
 
 	code, message, err = c.conn.ReadResponse(2)
 	return
@@ -228,7 +234,10 @@ func (c *Conn) Retrieve(fname string, dconn net.Conn) (contents []byte, code int
 	if err != nil {
 		return nil, code, message, err
 	}
-	dconn.Close()
+	err = dconn.Close()
+	if err != nil {
+		return nil, code, message, err
+	}
 
 	code, message, err = c.conn.ReadResponse(2)
 	return
@@ -246,7 +255,10 @@ func (c *Conn) RetrieveTo(fname string, dconn net.Conn, w io.Writer) (written in
 	if err != nil {
 		return 0, code, message, err
 	}
-	dconn.Close()
+	err = dconn.Close()
+	if err != nil {
+		return 0, code, message, err
+	}
 
 	code, message, err = c.conn.ReadResponse(2)
 	return


### PR DESCRIPTION
Hi there,

I've learned a lot about FTP and Go through reading your code, the spec and troubleshooting issues on a specific FTP server. This particular server expects the client to close the data connection before it will issue the 2XX message on the control connection.

I am still not sure if this is expected behavior after reading and re-reading the spec (http://www.ietf.org/rfc/rfc959.txt), but it seems as if other FTP clients/libraries tend to close the data connection before reading from the control connection again:

https://github.com/ruby/ruby/blob/trunk/lib/net/ftp.rb#L487
http://sources.debian.net/src/netkit-ftp/0.17-30/ftp/ftp.c#L1249

What do you think? It seems as if the tinyftp library could be refactored to automatically create and close the passive connection in `List()`, `NameList()`, `Retrieve()`, and `RetriveTo()`. If you agree, I could take a first pass.

Thank you!
